### PR TITLE
Update 2012-11-28-ruby-reads-like-english.markdown

### DIFF
--- a/_posts/2012-11-28-ruby-reads-like-english.markdown
+++ b/_posts/2012-11-28-ruby-reads-like-english.markdown
@@ -29,7 +29,7 @@ What about some code obfuscation just for the lulz?
 
 p JSON.parse(open(<<-RUBY
 
-  ugg  c  , !!e  h   ol
+  ugg  cf  , !!e  h   ol
   t  r z  f .  b  e t
   !nc  v  ! i1!    n
   pg   v  i v  g   l


### PR DESCRIPTION
Fix that http -> https redirect (actually ruby 2.4.0 fixed it :) )

http://blog.bigbinary.com/2017/03/02/open-uri-in-ruby-2-4-allows-http-to-https-redirection.html